### PR TITLE
Providing default return value when parsing fails.

### DIFF
--- a/AutoParse.Tests/ScratchTests.cs
+++ b/AutoParse.Tests/ScratchTests.cs
@@ -15,6 +15,9 @@ namespace AutoParse.Tests
             Console.WriteLine("0009998".TryParse<long>());
             Console.WriteLine("0009998".TryParse<double>());
 
+            Assert.AreEqual("1.5".TryParse(10), 10, "Default value should be returned when string is not parsable.");
+            Assert.AreEqual("1.5".TryParse<int>(), default(int), "default(T) should be returned when string is not parsable and no default has been provided.");
+            
             Console.WriteLine("10-25-2013".TryParseNullable<DateTime>().HasValue);
         }
     }

--- a/AutoParse/AutoParse.cs
+++ b/AutoParse/AutoParse.cs
@@ -1,6 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Reflection;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Remoting.Messaging;
 
 namespace AutoParse
 {
@@ -25,6 +30,12 @@ namespace AutoParse
         {
             var parser = GetParser<T>();
             return value.TryParse(parser);
+        }
+
+        public static T TryParse<T>(this string value, T defaultValue)
+        {
+            var parsedValue = value.TryParse<T>();
+            return (EqualityComparer<T>.Default.Equals(parsedValue, default(T))) ? defaultValue : parsedValue;
         }
 
         public static T? TryParseNullable<T>(this string value)

--- a/AutoParse/AutoParse.cs
+++ b/AutoParse/AutoParse.cs
@@ -1,11 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Reflection;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.Remoting.Messaging;
 
 namespace AutoParse
 {
@@ -42,7 +36,7 @@ namespace AutoParse
             where T : struct
         {
             var parser = GetParser<T>();
-            return value.TryParseNullable<T>(parser);
+            return value.TryParseNullable(parser);
         }
 
         private static TryParser<T> GetParser<T>()

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@
 <p>In cases where you don't really have any conditional logic, but don't want to fail if the value cannot be parsed, AutoParse simplifies it:</p>
 <pre>
 	<code>
-		var number = "123456".Parse&lt;int&gt;();
+		var number = "123456".TryParse&lt;int&gt;();
+	</code>
+</pre>
+<br/>
+<p>In cases where you want to specify a default value when parsing fails then you can use:</p>
+<pre>
+	<code>
+		// "1.5".TryParse&lt;int&gt;() will return 0 by default.
+		// By providing a default parameter you can control the return value when parsing fails
+		var number = "1.5".TryParse&lt;int&gt;(10);
+		
+		// OR the simplified version
+		var number = "1.5".TryParse(10);
 	</code>
 </pre>

--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@
 <p>In cases where you want to specify a default value when parsing fails then you can use:</p>
 <pre>
 	<code>
-		// "1.5".TryParse&lt;int&gt;() will return 0 by default.
-		// By providing a default parameter you can control the return value when parsing fails
-		var number = "1.5".TryParse&lt;int&gt;(10);
+		// The following line will return 0
+		var number = "1.5".TryParse&lt;int&gt;();
 		
-		// OR the simplified version
+		// Provide a default to control the return value when parsing fails
+		// The following line will return 10
+		var number = "1.5".TryParse&lt;int&gt;(10);		
+		
+		// simplified version
+		// The following line will return 10
 		var number = "1.5".TryParse(10);
 	</code>
 </pre>


### PR DESCRIPTION
Currently "2.5".TryParse<int>() will return 0.
With these changes "2.5".TryParse<int>(10) will return 10 or whatever default value the user decides to use for when parsing fails instead of returning default(T).
